### PR TITLE
Add composite scene w toggle button to show the problem

### DIFF
--- a/composite_scene.gd
+++ b/composite_scene.gd
@@ -1,0 +1,7 @@
+extends Node
+
+@export var overlay_scene : Node3D
+
+
+func _on_button_pressed():
+	overlay_scene.ground.visible = not overlay_scene.ground.visible

--- a/composite_scene.tscn
+++ b/composite_scene.tscn
@@ -1,0 +1,64 @@
+[gd_scene load_steps=4 format=3 uid="uid://d4ccywf4en507"]
+
+[ext_resource type="Script" path="res://composite_scene.gd" id="1_c34qe"]
+[ext_resource type="PackedScene" uid="uid://cxo2vo7uailuv" path="res://main.tscn" id="1_ixs4j"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_idovd"]
+size = Vector3(50, 1, 50)
+
+[node name="composite_scene" type="Node" node_paths=PackedStringArray("overlay_scene")]
+script = ExtResource("1_c34qe")
+overlay_scene = NodePath("SubViewportContainer/SubViewport/Node3D")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.965926, 0.258819, 0, -0.258819, 0.965926, 0, 1, 4)
+
+[node name="OmniLight3D" type="OmniLight3D" parent="Camera3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.756983, -2.8251)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.518733, 0)
+mesh = SubResource("BoxMesh_idovd")
+skeleton = NodePath("")
+
+[node name="SubViewportContainer" type="SubViewportContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+stretch = true
+
+[node name="SubViewport" type="SubViewport" parent="SubViewportContainer"]
+own_world_3d = true
+transparent_bg = true
+handle_input_locally = false
+size = Vector2i(1152, 648)
+render_target_update_mode = 4
+
+[node name="Node3D" parent="SubViewportContainer/SubViewport" instance=ExtResource("1_ixs4j")]
+
+[node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Button" type="Button" parent="Control"]
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -565.0
+offset_top = -51.0
+offset_right = -20.0
+offset_bottom = -20.0
+grow_horizontal = 0
+grow_vertical = 0
+text = "Toggle the mesh supposed to be transparent but still render shadows"
+
+[connection signal="pressed" from="Control/Button" to="." method="_on_button_pressed"]

--- a/main.gd
+++ b/main.gd
@@ -1,0 +1,3 @@
+extends Node3D
+
+@export var ground : CSGBox3D

--- a/main.tscn
+++ b/main.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://cxo2vo7uailuv"]
+[gd_scene load_steps=5 format=3 uid="uid://cxo2vo7uailuv"]
+
+[ext_resource type="Script" path="res://main.gd" id="1_vpltj"]
 
 [sub_resource type="Environment" id="Environment_3ae0e"]
 
@@ -10,7 +12,9 @@ transparency = 1
 blend_mode = 3
 albedo_color = Color(1, 1, 1, 0)
 
-[node name="Node3D" type="Node3D"]
+[node name="Node3D" type="Node3D" node_paths=PackedStringArray("ground")]
+script = ExtResource("1_vpltj")
+ground = NodePath("CSGBox3D")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -0.360827, 0.932633, 0, -0.932633, -0.360827, 0, 6, 0)
@@ -20,14 +24,17 @@ shadow_enabled = true
 environment = SubResource("Environment_3ae0e")
 
 [node name="CSGBox3D3" type="CSGBox3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -6)
-size = Vector3(10, 0.5, 10)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -7.55246)
+size = Vector3(10, 0.5, 20)
 
 [node name="CSGBox3D2" type="CSGBox3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, -2.82677)
 material = SubResource("StandardMaterial3D_3dtfv")
 
 [node name="CSGBox3D" type="CSGBox3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
-size = Vector3(12, 0.5, 12)
+transform = Transform3D(0.83552, 0, -0.54946, 0, 1, 0, 0.54946, 0, 0.83552, -1.33175, 0.0965548, 3.52752)
+size = Vector3(12, 0.5, 11.6353)
 material = SubResource("StandardMaterial3D_gjd3i")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(0.812393, 0.371704, -0.449282, 0.0610828, 0.712005, 0.699512, 0.579903, -0.595722, 0.555723, -1.51592, 4.65333, -0.628159)

--- a/project.godot
+++ b/project.godot
@@ -11,10 +11,10 @@ config_version=5
 [application]
 
 config/name="Tester-Helper"
-run/main_scene="res://main.tscn"
+run/main_scene="res://composite_scene.tscn"
 config/features=PackedStringArray("4.1", "Forward Plus")
 config/icon="res://icon.svg"
 
-[autoload]
+[dotnet]
 
-Gamestate="*res://gamestate.gd"
+project/assembly_name="Tester-Helper"


### PR DESCRIPTION
Thank you for trying to help!

I have added a new scene that demonstrates the problem: the transparent mesh doesn't work as hoped when used in a viewport (which is necessary for positioning standalone scenes on top of each other).

I added a button which lets you toggle the transparent ground. If it's hidden, the cube and its shadow can be seen on the solid ground. But, if the transparent ground is turned off, the shadow also gets cut off, even though it was supposed to remain visible. It looks like the shadow is only rendered by the solid, light gray mesh.